### PR TITLE
Updated the RealADSB jar file download path

### DIFF
--- a/realadsb/Dockerfile
+++ b/realadsb/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/share/man/man1 && \
   # Add a user
   useradd -s /bin/bash realadsb && \
   # Get the RealADSB Java application
-  wget -q http://www.realadsb.com/dl/adsb_hub_331.jar && \
+  wget -q http://www.realadsb.com/dl/adsb_hub3.jar && \
   # Clean up apt lists
   apt-get clean &&  \
   rm -rf /var/lib/apt/lists/*

--- a/realadsb/entrypoint.sh
+++ b/realadsb/entrypoint.sh
@@ -27,4 +27,4 @@ cat <<-EOF > /home/realadsb/config.json
 }
 EOF
 
-/usr/bin/java -jar /home/realadsb/adsb_hub_331.jar /home/realadsb/config.json
+/usr/bin/java -jar /home/realadsb/adsb_hub3.jar /home/realadsb/config.json


### PR DESCRIPTION
Fixes #1 

Testing steps:

```bash
# Clone repo from fresh if you need
# Just run git checkout origin/update-realadsb-jar if already checked out
git clone -b update-realadsb-jar https://github.com/jnsgruk/flypi
# Enter the directory
cd flypi
# Bring up the containers, rebuilding each
docker-compose build --no-cache realadsb
# Bring up the new container
docker-compose up -d
```