### PR TITLE
fix(dump1090): lighttpd configuration has a missing comma

### DIFF
--- a/modules/dump1090.nix
+++ b/modules/dump1090.nix
@@ -70,7 +70,7 @@ in
 
         alias.url += (
           "/dump1090-fa/data/" => "/run/dump1090-fa/",
-          "/dump1090-fa/" => "${cfg.package}/share/dump1090"
+          "/dump1090-fa/" => "${cfg.package}/share/dump1090",
           "/data/receiver.json" => "/run/dump1090-fa/receiver.json",
           "/status.json" => "/run/dump1090-fa/stats.json",
           "/data/" => "/run/dump1090-fa/",


### PR DESCRIPTION
The lighttpd service immediately crashes, as there is a missing comma after the `dump1090-fa` alias.

This PR adds the missing comma, so the lighttpd configuration will be valid.
