### PR TITLE
fix: add mainProgram attribute to packages

### DIFF
--- a/pkgs/piaware/default.nix
+++ b/pkgs/piaware/default.nix
@@ -38,5 +38,6 @@ pkgs.stdenv.mkDerivation rec {
     license = lib.licenses.bsd2;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ jnsgruk ];
+    mainProgram = "piaware";
   };
 }

--- a/pkgs/realadsb/default.nix
+++ b/pkgs/realadsb/default.nix
@@ -36,6 +36,7 @@ pkgs.stdenv.mkDerivation rec {
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [ jnsgruk ];
+    mainProgram = "realadsb";
   };
 
 }


### PR DESCRIPTION
Adds missing `mainProgram` attribute to packages.

Fixes #36 