### PR TITLE
feat(dump1090-fa): Adapt dump1090 for release 25.05 where native dump1090-fa package is available

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745930157,
-        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,27 +24,30 @@
     in
     {
       overlay = final: prev: {
-        dump1090-fa = prev.dump1090.overrideAttrs (oldAttrs: rec {
-          buildFlags = oldAttrs.buildFlags ++ [ "faup1090" ];
+        dump1090-fa =
+          if prev ? dump1090-fa 
+          then prev.dump1090-fa  # Use the existing package
+          else prev.dump1090.overrideAttrs (oldAttrs: rec {
+            buildFlags = oldAttrs.buildFlags ++ [ "faup1090" ];
 
-          installPhase = ''
-            runHook preInstall
+            installPhase = ''
+              runHook preInstall
 
-            mkdir -p $out/bin $out/share $out/etc/default
-            cp -v dump1090 $out/bin/dump1090-fa
-            cp -v view1090 faup1090 $out/bin
-            cp -vr public_html $out/share/dump1090
+              mkdir -p $out/bin $out/share $out/etc/default
+              cp -v dump1090 $out/bin/dump1090-fa
+              cp -v view1090 faup1090 $out/bin
+              cp -vr public_html $out/share/dump1090
 
-            substituteInPlace debian/start-dump1090-fa \
-              --replace "/etc/default/dump1090-fa" "$out/etc/default/dump1090-fa" \
-              --replace "/usr/bin/dump1090-fa" "$out/bin/dump1090-fa"
+              substituteInPlace debian/start-dump1090-fa \
+                --replace "/etc/default/dump1090-fa" "$out/etc/default/dump1090-fa" \
+                --replace "/usr/bin/dump1090-fa" "$out/bin/dump1090-fa"
 
-            install -m 0755 -D debian/start-dump1090-fa $out/bin/start-dump1090-fa
-            install -m 0644 -D debian/dump1090-fa.default $out/etc/default/dump1090-fa
+              install -m 0755 -D debian/start-dump1090-fa $out/bin/dump1090
+              install -m 0644 -D debian/dump1090-fa.default $out/etc/default/dump1090-fa
 
-            runHook postInstall
-          '';
-        });
+              runHook postInstall
+            '';
+          });
 
         fr24 = final.callPackage ./pkgs/fr24 { };
         piaware = final.callPackage ./pkgs/piaware { };

--- a/modules/dump1090.nix
+++ b/modules/dump1090.nix
@@ -61,7 +61,7 @@ in
         DynamicUser = true;
         Group = "plugdev";
         RuntimeDirectory = "dump1090-fa";
-        ExecStart = "${cfg.package}/bin/start-dump1090-fa --write-json /run/dump1090-fa --write-json-every 1 --quiet";
+        ExecStart = "${cfg.package}/bin/dump1090 --write-json /run/dump1090-fa --write-json-every 1 --quiet";
         Restart = "on-failure";
       };
     };

--- a/pkgs/realadsb/default.nix
+++ b/pkgs/realadsb/default.nix
@@ -5,7 +5,7 @@ pkgs.stdenv.mkDerivation rec {
 
   src = pkgs.fetchurl {
     url = "http://www.realadsb.com/dl/adsb_hub3.jar";
-    hash = "sha256-cVWruIGdYbGA1oassLu13lHsSLYFk7kmu9UXgOR1Msw=";
+    hash = "sha256-HHyolGrIan2YFsLfYIuZkMeMWeYqGCQRCSQnra2X9PI=";
     # Server returns HTTP 406 with standard user agent 🤷‍♂️
     curlOpts = "--user-agent Foobar";
   };


### PR DESCRIPTION
Adapted the **dump1090-fa** package overlay to consider whether native package is available.
@jnsgruk please have in mind, that I didn't test this in previous release, i.e. _24.11_.